### PR TITLE
Expose fullchain.pem certificate, required by openfire, and also ngin…

### DIFF
--- a/deploy/info.php
+++ b/deploy/info.php
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////////////////////
 
 $app['basename'] = 'lets_encrypt';
-$app['version'] = '1.10.5';
+$app['version'] = '1.10.6';
 $app['release'] = '1';
 $app['vendor'] = 'WikiSuite';
 $app['packager'] = 'WikiSuite';

--- a/libraries/Lets_Encrypt.php
+++ b/libraries/Lets_Encrypt.php
@@ -328,6 +328,7 @@ class Lets_Encrypt extends Software
             $cert_files[$certificate]['certificate-filename'] = $base_path . 'cert.pem';
             $cert_files[$certificate]['key-filename'] = $base_path . 'privkey.pem';
             $cert_files[$certificate]['intermediate-filename'] = $base_path . 'chain.pem';
+            $cert_files[$certificate]['fullchain-filename'] = $base_path . 'fullchain.pem';
         }
 
         return $cert_files;

--- a/packaging/app-lets-encrypt.spec
+++ b/packaging/app-lets-encrypt.spec
@@ -1,7 +1,7 @@
 
 Name: app-lets-encrypt
 Epoch: 1
-Version: 1.10.5
+Version: 1.10.6
 Release: 1%{dist}
 Summary: Let's Encrypt
 License: GPLv3


### PR DESCRIPTION
…x and several other.  Missing intermediate certificates by using cert.pem causes hard to diagnose problems, where browsers work fine, but things like wget throw 'Unable to locally verify the issuer's authority.' errors

@pcbaldwin While this works fine with the companion pull request in app-openfire, and won't break anything, this new 'fullchain-filename' convention should be documented in https://github.com/clearos/app-certificate-manager , nginx and a lot of other software will need it.